### PR TITLE
Add user based instance configuration plumbing.

### DIFF
--- a/iscc_service_generator/settings.py
+++ b/iscc_service_generator/settings.py
@@ -31,6 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    "constance",
     "admin_interface",
     "colorfield",
     "django.contrib.admin",
@@ -148,4 +149,50 @@ Q_CLUSTER = {
     "bulk": 10,
     "orm": "default",
     "sync": True,
+}
+
+
+CONSTANCE_CONFIG = {
+    "PROCESSING_TIMEOUT": (
+        5,
+        "Number of seconds to wait for a background task before returning an async task instead",
+    ),
+    "ENABLE_LIST_ENDPOINTS": (
+        False,
+        "Enables REST Api endpoints that can list objects "
+        "(do not enable on public instances without authentication)",
+    ),
+    "RESULT_HOOK_URL": (
+        "",
+        "An URL to which the background processing results should be deliverd "
+        "(must be a an endpoint accepting POST requests with a json body)",
+        "url_field",
+    ),
+    "RATE_LIMIT": (
+        "16/m",
+        "IP based rate limit for API calls. For possible values see: ",
+        "rate_limit_field",
+    ),
+}
+CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
+CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
+CONSTANCE_ADDITIONAL_FIELDS = {
+    "url_field": ["django.forms.fields.URLField", {"widget": "django.forms.URLInput"}],
+    "rate_limit_field": [
+        "django.forms.fields.ChoiceField",
+        {
+            "widget": "django.forms.Select",
+            "choices": (
+                ("4/m", "4 requests per minute"),
+                ("8/m", "8 requests per minute"),
+                ("16/m", "16 requests per minute"),
+                ("32/m", "32 requests per minute"),
+                ("64/m", "64 requests per minute"),
+                ("128/m", "128 requests per minute"),
+                ("254/m", "254 requests per minute"),
+                ("512/m", "512 requests per minute"),
+                ("1024/m", "1024 requests per minute"),
+            ),
+        },
+    ],
 }

--- a/iscc_service_generator/settings.py
+++ b/iscc_service_generator/settings.py
@@ -170,7 +170,7 @@ CONSTANCE_CONFIG = {
     ),
     "RATE_LIMIT": (
         "16/m",
-        "IP based rate limit for API calls. For possible values see: ",
+        "IP based rate limit for API calls",
         "rate_limit_field",
     ),
 }

--- a/iscc_service_generator/urls.py
+++ b/iscc_service_generator/urls.py
@@ -5,12 +5,14 @@ from django.conf import settings
 from django.contrib.auth.apps import AuthConfig
 from admin_interface.admin import Theme
 from django_q.apps import DjangoQConfig
+from constance.apps import ConstanceConfig
 
 from .api_v1 import api
 
 # Override some defaults
 AuthConfig.verbose_name = "Users"
-DjangoQConfig.verbose_name = "Background Tasks"
+DjangoQConfig.verbose_name = "Tasks"
+ConstanceConfig.verbose_name = "Settings"
 admin.site.unregister(Theme)
 
 urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + [

--- a/poetry.lock
+++ b/poetry.lock
@@ -222,6 +222,18 @@ python-versions = "*"
 Pillow = ">=5.0"
 
 [[package]]
+name = "django-constance"
+version = "2.8.0"
+description = "Django live settings with pluggable backends, including Redis."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+database = ["django-picklefield"]
+redis = ["redis"]
+
+[[package]]
 name = "django-flat-responsive"
 version = "2.0"
 description = "An extension for Django admin that makes interface mobile friendly."
@@ -1033,7 +1045,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "41712ea1c4acf4f9a8026d37f2dafd437a73f589069058cf02b4fee9fd449eb2"
+content-hash = "45b605c8f34424ce6ec3d04512fadf8a057a8d4fa406a54396403c1a1133c66a"
 
 [metadata.files]
 annoy = [
@@ -1210,6 +1222,10 @@ django-admin-interface = [
 django-colorfield = [
     {file = "django-colorfield-0.6.3.tar.gz", hash = "sha256:441172f8c6024f70b01e3f63195fe83afc554387b34ad999880e86fde989e5af"},
     {file = "django_colorfield-0.6.3-py3-none-any.whl", hash = "sha256:97625246fb5c4f4a17c9d83b2406a3c98dd9545c40c47741a7b62f7284609910"},
+]
+django-constance = [
+    {file = "django-constance-2.8.0.tar.gz", hash = "sha256:0a492454acc78799ce7b9f7a28a00c53427d513f34f8bf6fdc90a46d8864b2af"},
+    {file = "django_constance-2.8.0-py3-none-any.whl", hash = "sha256:60fec73e397d5f4f7440f611b18d3e7ce5342647f316fedc47b62e1411c849e7"},
 ]
 django-flat-responsive = [
     {file = "django-flat-responsive-2.0.tar.gz", hash = "sha256:451caa2700c541b52fb7ce2d34d3d8dee9e980cf29f5463bc8a8c6256a1a6474"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ blake3 = "^0.3.1"
 humanize = "^3.14.0"
 django-q = "^1.3.9"
 iscc = "1.1.0b15"
+django-constance = "^2.8.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"


### PR DESCRIPTION
Installed django-constance to add user based instance configuration and created some configuration settings with defaults. Users will be able to configure there ISCC Generator Service instance via the dashboard.

Future improvements:

- Use [django-redis](https://github.com/jazzband/django-redis) as cache backend for constance.